### PR TITLE
Fix: Include non-exported functions when importing modules

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -120,6 +120,9 @@ pub fn process_imports(
                     };
 
                     map.insert(function_name, (params, function.return_type.clone()));
+                }
+
+                for function in &program.functions {
                     funcs.push(function.clone());
                 }
 


### PR DESCRIPTION
## Description
This PR fixes the issue where importing a module with exported functions that call non-exported helper functions would result in undefined symbol errors.

## Problem
When importing a module that contains an `export fn` which internally calls a non-exported function, the compiler/runtime threw an error that the internal function is undefined.

## Solution
Modified `process_imports` in `src/utils/mod.rs` to include all functions from imported modules in codegen, not just exported ones. Only exported functions remain in the public API symbol map.

## Example
### This now works:
```rs
fn string_from_cstr(ptr: rawptr) -> string {
    return ptr as string;
}

export fn read_line() -> string {
    // ... implementation using string_from_cstr
    return string_from_cstr(buffer);
}
```

## Fixes
- Fixes #2

## Changes
- All functions from imported modules are now included in codegen
- Exported functions are still properly tracked in the public API
- Non-exported helper functions are available for use by exported functions